### PR TITLE
Try having travis get latest version of mongo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,15 @@ language: node_js
 services:
   - mongodb
 
+before_install:
+  - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
+  - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
+  - "sudo apt-get update"
+  - "sudo apt-get install mongodb-org-server"
+
 before_script:
-  npm install -g gulp
+  - "until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done"
+  - "npm install -g gulp"
 
 #test on two node.js versions: 0.6 and 0.8
 node_js:


### PR DESCRIPTION
This fixes the failing Travis builds due to Travis using a very old version of Mongo that by default does not yet support the `findAndModify()` param format we use (added in 2.6, which was released in 2014).
