### PR TITLE
Fake data generation method.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "babel": "^5.8.23",
     "babel-runtime": "^5.8.20",
+    "faker": "^3.0.1",
     "hooker": "^0.2.3",
     "lodash": "^3.9.3",
     "mongodb": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "babel": "^5.8.23",
     "babel-runtime": "^5.8.20",
-    "faker": "^3.0.1",
+    "faker": "git+https://github.com/bsouthga/faker.js.git#ddc474344d1b81a073e13a1047eec7589413759b",
     "hooker": "^0.2.3",
     "lodash": "^3.9.3",
     "mongodb": "^1.4.3",

--- a/src/classes/Collection.js
+++ b/src/classes/Collection.js
@@ -114,13 +114,10 @@ function fakeField(field) {
 
   case 'link':
   case 'mongoid':
-    const idString = faker
-      .random
-      .uuid()
-      .replace(/-/g, '')
-      .slice(0, 24);
-
-    return ObjectId(idString);
+    let i = 24,
+        s = '';
+    while(i--) s += faker.random.number(15).toString(16);
+    return ObjectId(s);
 
   case 'boolean':
     return faker.random.boolean();

--- a/src/classes/Collection.js
+++ b/src/classes/Collection.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import hooker from 'hooker';
+import faker from 'faker';
 
 import Type from './Type';
 import { ObjectType } from '../builtins';
@@ -78,6 +79,77 @@ function defineDocumentProperties(dp) {
 function denormalPopulate(collection, obj, denormalAlreadyDone) {
   const denormal = !denormalAlreadyDone && collection.denormal;
   return denormal ? collection.populate(denormal, obj, true) : Promise.resolve();
+}
+
+
+
+/**
+ * Recurse into schema and populate fake document
+ */
+function fakeField(field) {
+  const def = _.get(field, 'is.def') || field.def;
+
+  if (!def) throw new Error('No field.def property to fake on! ' + JSON.stringify(field));
+
+  switch (def.name) {
+  case 'integer':
+  case 'float':
+  case 'double':
+  case 'number':
+    return faker.random.number();
+
+  case 'email':
+    return faker.internet.email();
+
+  case 'url':
+    return faker.internet.url();
+
+  case 'date':
+    const date = faker.date.past();
+    date.setMilliseconds(0);
+    return date;
+
+  case 'image':
+    return faker.image.avatar();
+
+  case 'link':
+  case 'mongoid':
+    const idString = faker
+      .random
+      .uuid()
+      .replace(/-/g, '')
+      .slice(0, 24);
+
+    return ObjectId(idString);
+
+  case 'boolean':
+    return faker.random.boolean();
+
+  case 'array':
+    return _.range(2).map(() => fakeField(field.of));
+
+  case 'object':
+    const key = def.name === 'link'
+      ? 'link.def.fields'
+      : 'fields';
+
+    return _.reduce(_.get(field, key), (out, value, key) => {
+      out[key] = fakeField(value);
+      return out;
+    }, {});
+
+  // default to string
+  default: return faker.name.lastName();
+  }
+}
+
+
+function fakeDocument(schema) {
+  const doc = {};
+  _.each(schema, (field, name) => {
+    doc[name] = fakeField(field);
+  });
+  return doc;
 }
 
 
@@ -199,6 +271,24 @@ export default class Collection {
 
     return CollectionInstance;
   }
+
+  async fake({ n, schemaOpts, seed } = {}) {
+    // get doc schema
+    const collection = this,
+          schema = await collection.fieldsFor(schemaOpts);
+
+    // seed if provided, else reset
+    faker.seed(seed);
+
+    if (n === undefined) {
+      return new collection(fakeDocument(schema));
+    } else {
+      const out = [];
+      while (n--) out.push(new collection(fakeDocument(schema)));
+      return out;
+    }
+  }
+
 
   idToUid(id) {
     return this.id + id;

--- a/test/test.js
+++ b/test/test.js
@@ -873,20 +873,20 @@ describe('tyranid', function() {
 
       describe( 'Fake data generation', function() {
 
+        const seed = 100;
+
         it('faker: should successfully create valid document', async () => {
-          const fakeDoc = await Person.fake({ seed: 100 });
+          const fakeDoc = await Person.fake({ seed });
           expect(fakeDoc, 'Fake document should be valid instance of person').to.be.instanceOf(Person);
           fakeDoc.$validate();
         });
 
         it('faker: should produce same document given same seed', async () => {
-          const seed = 100,
-                fakeDoc1 = JSON.stringify(await Person.fake({ seed }), null, 2),
+          const fakeDoc1 = JSON.stringify(await Person.fake({ seed }), null, 2),
                 fakeDoc2 = JSON.stringify(await Person.fake({ seed }), null, 2);
 
           expect(fakeDoc2).to.deep.equal(fakeDoc1);
         });
-
 
       });
 

--- a/test/test.js
+++ b/test/test.js
@@ -853,6 +853,25 @@ describe('tyranid', function() {
           });
       });
 
+      describe( 'Fake data generation', function() {
+
+        it('faker: should successfully create valid document', async () => {
+          const fakeDoc = await Person.fake({ seed: 100 });
+          expect(fakeDoc, 'Fake document should be valid instance of person').to.be.instanceOf(Person);
+          fakeDoc.$validate();
+        });
+
+        it('faker: should produce same document given same seed', async () => {
+          const seed = 100,
+                fakeDoc1 = JSON.stringify(await Person.fake({ seed }), null, 2),
+                fakeDoc2 = JSON.stringify(await Person.fake({ seed }), null, 2);
+
+          expect(fakeDoc2).to.deep.equal(fakeDoc1);
+        });
+
+
+      });
+
     });
 
   });


### PR DESCRIPTION
Addresses #31 

This PR adds a `async fake({ n, schemaOpts, seed } = {})` method to collections, which returns a fake document (or documents) generated based on the schema. The method can be provided a seed for consistent values, as well as options for a dynamic schema.
