### PR TITLE
Es6 modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "babel-core": "6.7.2",
-    "babel-plugin-add-module-exports": "0.1.2",
     "babel-plugin-transform-class-properties": "6.6.0",
-    "babel-plugin-transform-flow-strip-types": "6.7.0",
     "babel-preset-es2015-node4": "2.0.3",
     "babel-preset-stage-0": "6.5.0",
     "chalk": "^1.1.1",
@@ -53,9 +51,7 @@
       "es2015-node4"
     ],
     "plugins": [
-      "transform-class-properties",
-      "transform-flow-strip-types",
-      "add-module-exports"
+      "transform-class-properties"
     ]
   }
 }

--- a/src/core/collection.js
+++ b/src/core/collection.js
@@ -22,11 +22,10 @@ import {
   toClient
 } from '../common';
 
-import {
+const {
   collections,
   labelize
-} from '../tyr';
-
+} = Tyr;
 
 /**
  *  Given an options pojo with { tyranid: {} },

--- a/src/core/namePath.js
+++ b/src/core/namePath.js
@@ -2,7 +2,7 @@
 // cannot use import because @isomorphic
 const _ = require('lodash');
 
-const Tyr = require('../tyr');
+const Tyr = require('../tyr').default;
 
 /**
  * NOTE: This cannot be a ES6 class because it is isomorphic

--- a/test/models/book.js
+++ b/test/models/book.js
@@ -1,4 +1,4 @@
-var tyr = require('../../src/tyranid');
+import tyr from '../../src/tyranid';
 
 var Book = new tyr.Collection({
   id: 'b00',
@@ -13,4 +13,4 @@ var Book = new tyr.Collection({
   primaryKey: { field: 'isbn', defaultMatchIdOnInsert: true }
 });
 
-module.exports = Book;
+export default Book;

--- a/test/models/department.js
+++ b/test/models/department.js
@@ -1,4 +1,4 @@
-var tyr = require('../../src/tyranid');
+import tyr from '../../src/tyranid';
 
 var Department = new tyr.Collection({
   id: 't05',
@@ -17,4 +17,4 @@ var Department = new tyr.Collection({
   }
 });
 
-module.exports = Department;
+export default Department;

--- a/test/models/job.js
+++ b/test/models/job.js
@@ -1,4 +1,4 @@
-var tyr = require('../../src/tyranid');
+import tyr from '../../src/tyranid';
 
 var Job = new tyr.Collection({
   id: 'j00',
@@ -22,4 +22,4 @@ Job.prototype.isSoftware = function() {
   return this.name.substring(0, 8) === 'Software';
 };
 
-module.exports = Job;
+export default Job;

--- a/test/models/location.js
+++ b/test/models/location.js
@@ -1,4 +1,3 @@
-
 import Tyr from '../../src/tyranid';
 
 const Location = new Tyr.Collection({

--- a/test/models/organization.js
+++ b/test/models/organization.js
@@ -1,4 +1,4 @@
-var tyr = require('../../src/tyranid');
+import tyr from '../../src/tyranid';
 
 var Organization = new tyr.Collection({
   id: 't04',
@@ -10,4 +10,4 @@ var Organization = new tyr.Collection({
   }
 });
 
-module.exports = Organization;
+export default Organization;

--- a/test/models/task.js
+++ b/test/models/task.js
@@ -1,5 +1,5 @@
-var tyr = require('../../src/tyranid'),
-    User = require('./user');
+import tyr from '../../src/tyranid';
+import User from './user';
 
 var Department = {
   is: 'object',
@@ -28,4 +28,4 @@ var Task = new tyr.Collection({
   }
 });
 
-module.exports = Task;
+export default Task;

--- a/test/models/user.js
+++ b/test/models/user.js
@@ -1,5 +1,4 @@
-
-var tyr = require('../../src/tyranid');
+import tyr from '../../src/tyranid';
 
 var Friend = {
   is: 'object',
@@ -69,4 +68,4 @@ var User = new tyr.Collection({
 
 User.Sibling = Sibling;
 
-module.exports = User;
+export default User;

--- a/test/test.js
+++ b/test/test.js
@@ -4,24 +4,33 @@
     4. document Tyr.db, Collection.db
 
  */
+import Tyr            from '../src/tyranid';
+import chai           from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import pmongo         from 'promised-mongo';
+import _              from 'lodash';
+import Field          from '../src/core/field';
+import Type           from '../src/core/type';
+import UnitType       from '../src/unit/unitType';
+import Unit           from '../src/unit/unit';
+import Units          from '../src/unit/units';
+import Role           from './models/role.js'; // require to get extra link in prototype chain
 
-var Tyr            = require('../src/tyranid'),
-    NamePath       = Tyr.NamePath,
-    $all           = Tyr.$all,
-    chai           = require('chai'),
-    chaiAsPromised = require('chai-as-promised'),
-    pmongo         = require('promised-mongo'),
-    expect         = chai.expect,
-    assert         = chai.assert,
-    _              = require('lodash'),
-    Field          = require('../src/core/field'),
-    Type           = require('../src/core/type'),
-    UnitType       = require('../src/unit/unitType'),
-    Unit           = require('../src/unit/unit'),
-    Units          = require('../src/unit/units'),
-    ObjectId       = require('promised-mongo').ObjectId,
 
-    Log            = Tyr.Log;
+const {
+  ObjectId
+} = pmongo;
+
+const {
+  NamePath,
+  $all,
+  Log
+} = Tyr;
+
+const {
+  expect,
+  assert
+} = chai;
 
 
 chai.use(chaiAsPromised);
@@ -183,7 +192,7 @@ describe('tyranid', function() {
   });
 
   describe('with model', function() {
-    var Job, Organization, Department, User, Task, Role, Book, Location,
+    var Job, Organization, Department, User, Task, Book, Location,
         TyrSchema, TyrSchemaType;
     //var Job2, Organization2, Department2, User2;
     var AdministratorRoleId = new ObjectId('55bb8ecff71d45b995ff8c83');
@@ -206,8 +215,6 @@ describe('tyranid', function() {
       Location = Tyr.byName.location;
       TyrSchema = Tyr.byName.tyrSchema;
       TyrSchemaType = Tyr.byName.tyrSchemaType;
-
-      Role = require('./models/role.js'); // require to get extra link in prototype chain
 
       await Organization.db.remove({});
       await Organization.db.insert([


### PR DESCRIPTION
PR for visibility. This corrects usage of es6 module default exports to remove the necessity of this plugin: https://github.com/59naga/babel-plugin-add-module-exports which was needed for these reasons: https://phabricator.babeljs.io/T2212

Additionally, it moves secure.query() filtering to be opt-in via a `{ tyranid: { secure: true } }` flag passed to find 
