### PR TITLE
Support direct ObjectId param for Collection.findOne(). Fixes #51.

### DIFF
--- a/src/core/collection.js
+++ b/src/core/collection.js
@@ -645,7 +645,12 @@ export default class Collection {
       }
       // fall through
     case 1:
-      opts.query = args[0];
+      // Support direct ObjectId arg, which will always query against _id
+      if (args[0] instanceof ObjectId) {
+        opts.query = { _id: args[0] }
+      } else {
+        opts.query = args[0];
+      }
     }
 
     if (opts === undefined) {

--- a/test/test.js
+++ b/test/test.js
@@ -482,6 +482,21 @@ describe('tyranid', function() {
         });
       });
 
+      it('should findOne() with direct ObjectId', function() {
+        return Role.findOne(AdministratorRoleId).then(function(doc) {
+          // Not instanceof check since Role is a class
+          expect(doc.$model).to.be.eql(Tyr.byName.role);
+        });
+      });
+
+      it('should findOne() with direct ObjectId + projection', function() {
+        return Role.findOne(AdministratorRoleId, { _id: false }).then(function(doc) {
+          expect(doc.$model).to.be.eql(Tyr.byName.role);
+          expect(doc._id).to.not.exist;
+          expect(doc.name).to.exist;
+        });
+      });
+
       it('should findOne() with projection', async function() {
         const doc = await User.findOne({ 'name.first': 'An' }, { name: 1 });
         expect(doc).to.be.an.instanceof(User);


### PR DESCRIPTION
See #51: Collection.findOne() no longers works when passing in an ObjectId directly

Esteemed reviewer:
- [x] @douglas-mason
- [x] @mcgrit
