### PR TITLE
Check that a and b are defined before doing equality check

### DIFF
--- a/src/tyr.js
+++ b/src/tyr.js
@@ -4,7 +4,7 @@ import _            from 'lodash';
 
 function equalCustomizer(a, b) {
   // cannot use instanceof because multiple versions of MongoDB driver are probably being used
-  if (a.constructor.name === 'ObjectID' && b.constructor.name === 'ObjectID') {
+  if (a && b && a.constructor.name === 'ObjectID' && b.constructor.name === 'ObjectID') {
     return a.equals(b);
   }
 


### PR DESCRIPTION
This check resulted in an error for me when comparing an ObjectId() to undefined.