### PR TITLE
Log override

### DIFF
--- a/src/log/log.js
+++ b/src/log/log.js
@@ -193,10 +193,10 @@ async function log(level, ...opts) {
 
   const config = Tyr.options,
         logOverride = config.logOverride,
-        consoleLogLevel = config.consoleLogLevel || config.logLevel || LogLevel.INFO,
+        consoleLogLevel = ('consoleLogLevel' in config) ? config.consoleLogLevel : (config.logLevel || LogLevel.INFO),
         dbLogLevel      = config.dbLogLevel      || config.logLevel || LogLevel.INFO;
 
-  if (level._id >= consoleLogLevel._id) {
+  if (consoleLogLevel && level._id >= consoleLogLevel._id) {
     let str = (level._id >= LogLevel.WARN ? chalk.red(level.code) : level.code);
     str +=' ' + chalk.yellow(moment(obj.on).format('YYYY.M.D HH:mm:ss'));
     if (obj.e) {

--- a/src/log/log.js
+++ b/src/log/log.js
@@ -192,6 +192,7 @@ async function log(level, ...opts) {
   }
 
   const config = Tyr.options,
+        logOverride = config.logOverride,
         consoleLogLevel = config.consoleLogLevel || config.logLevel || LogLevel.INFO,
         dbLogLevel      = config.dbLogLevel      || config.logLevel || LogLevel.INFO;
 
@@ -223,34 +224,35 @@ async function log(level, ...opts) {
   }
 
   if (level._id >= dbLogLevel._id) {
+    if (logOverride) return logOverride(obj);
     return Log.db.save(obj);
   }
 };
 
-Log.trace = async function() {
+Log.trace = function() {
   return log(LogLevel.TRACE, ...arguments);
 };
 
-Log.log = async function() {
+Log.log = function() {
   // TODO:  allow some way to specify the log level in opts ?
-  //Log.log = async function(level, ...opts) {
+  //Log.log = function(level, ...opts) {
 
   return log(LogLevel.LOG, ...arguments);
 };
 
-Log.info = async function() {
+Log.info = function() {
   return log(LogLevel.INFO, ...arguments);
 };
 
-Log.warn = async function() {
+Log.warn = function() {
   return log(LogLevel.WARN, ...arguments);
 };
 
-Log.error = async function() {
+Log.error = function() {
   return log(LogLevel.ERROR, ...arguments);
 };
 
-Log.fatal = async function() {
+Log.fatal = function() {
   return log(LogLevel.FATAL, ...arguments);
 };
 

--- a/src/tyranid.d.ts
+++ b/src/tyranid.d.ts
@@ -401,11 +401,12 @@ declare namespace Tyranid {
       glob: string;
     }
 
+    export type LogLevel = 'TRACE' | 'LOG' | 'INFO' | 'WARN' | 'ERROR' | 'FATAL';
 
     export interface ConfigOptions {
       db?: mongodb.Db;
-      consoleLogLevel?: 'ERROR';
-      dbLogLevel?: 'TRACE';
+      consoleLogLevel?: LogLevel;
+      dbLogLevel?: LogLevel;
       logOverride?: (obj: any) => void;
       secure?: Secure;
       cls?: boolean;

--- a/src/tyranid.d.ts
+++ b/src/tyranid.d.ts
@@ -406,6 +406,7 @@ declare namespace Tyranid {
       db?: mongodb.Db;
       consoleLogLevel?: 'ERROR';
       dbLogLevel?: 'TRACE';
+      logOverride?: (obj: any) => void;
       secure?: Secure;
       cls?: boolean;
       validate?: ValidationPattern[];

--- a/src/tyranid.d.ts
+++ b/src/tyranid.d.ts
@@ -407,7 +407,7 @@ declare namespace Tyranid {
       db?: mongodb.Db;
       consoleLogLevel?: LogLevel;
       dbLogLevel?: LogLevel;
-      logOverride?: (obj: any) => void;
+      logOverride?: (obj: any) => void | Promise<void>;
       secure?: Secure;
       cls?: boolean;
       validate?: ValidationPattern[];

--- a/src/tyranid.d.ts
+++ b/src/tyranid.d.ts
@@ -405,7 +405,7 @@ declare namespace Tyranid {
 
     export interface ConfigOptions {
       db?: mongodb.Db;
-      consoleLogLevel?: LogLevel;
+      consoleLogLevel?: LogLevel | false;
       dbLogLevel?: LogLevel;
       logOverride?: (obj: any) => void | Promise<void>;
       secure?: Secure;

--- a/src/tyranid.d.ts
+++ b/src/tyranid.d.ts
@@ -406,8 +406,9 @@ declare namespace Tyranid {
     export interface ConfigOptions {
       db?: mongodb.Db;
       consoleLogLevel?: LogLevel | false;
-      dbLogLevel?: LogLevel;
-      logOverride?: (obj: any) => void | Promise<void>;
+      externalLogLevel?: LogLevel | false;
+      dbLogLevel?: LogLevel | false;
+      externalLogger?: (obj: any) => void | Promise<void>;
       secure?: Secure;
       cls?: boolean;
       validate?: ValidationPattern[];


### PR DESCRIPTION
Allows for a hook to override `Log.db.save` -- for use with bunyan.